### PR TITLE
Add ability to set custom endpoint URL

### DIFF
--- a/src/GoogleCloudVision.php
+++ b/src/GoogleCloudVision.php
@@ -15,9 +15,13 @@ class GoogleCloudVision
 
     protected $version = "v1";
 
-    protected $urlEnpoint = "https://vision.googleapis.com/";
+    protected $endpoint = "https://vision.googleapis.com/";
 
     protected $key;
+
+    public function setEndpoint($newEndpoint) {
+        $this->endpoint = $newEndpoint;
+    }
 
     public function setImage($input, $type = "FILE")
     {
@@ -119,7 +123,7 @@ class GoogleCloudVision
         }
 
         if ($endpoint == "annotate") {
-            $url = $this->urlEnpoint . $this->version . "/images:annotate?key=" . $this->key;
+            $url = $this->endpoint . $this->version . "/images:annotate?key=" . $this->key;
         }
         return $this->requestServer($url, $this->requestBody);
     }


### PR DESCRIPTION
This change makes it possible to use a different
URL for the API endpoint, for example when a
proxy server is being used.

Also fixes a typo in the variable name.