### PR TITLE
Fix the base64 encoding - Issue #10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ examples/composer.lock
 .phpintel
 .idea
 .git
+.tags
 vendor/
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ php:
   - '7.0'
   - hhvm
   - nightly
+install: composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ php:
   - hhvm
   - nightly
 install: composer install
+script:
+  - vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-[![Build Status](https://travis-ci.org/thangman22/google-cloud-vision-php.svg?branch=master)](https://travis-ci.org/thangman22/google-cloud-vision-php)
+[![Build Status](https://travis-ci.org/pallant/google-cloud-vision-php.svg?branch=master)](https://travis-ci.org/pallant/google-cloud-vision-php)
+
 # GoogleCloudVisionPHP
 This project hosts the PHP library for the various RESTful based Google Cloud Vision API(s) [Read about Google Cloud Vision API] (https://cloud.google.com/vision/)
+
+This is a fork of http://github.com/thangman22/google-cloud-vision-php
 
 ##Features
 *   Support almost feature of Google Cloud Vision API (Version 1)
@@ -17,7 +20,7 @@ Add this to your composer.json
 
 ```json
 "require": {
-        "thangman22/google-cloud-vision-php": "*"
+        "pallant/google-cloud-vision-php": "*"
     }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,14 @@
 {
-    "name": "thangman22/google-cloud-vision-php",
+    "name": "pallant/google-cloud-vision-php",
     "type": "vcs",
     "authors": [
         {
             "name": "Warat Wongmaneekit",
             "email": "canopybanj@gmail.com"
+        },
+        {
+            "name": "Joel Day",
+            "email": "joel@pallant.digital"
         }
     ],
     "autoload": {

--- a/examples/composer.json
+++ b/examples/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "thangman22/google-cloud-vision-php": "^1.0"
+        "pallant/google-cloud-vision-php": "^1.0"
     }
 }

--- a/src/GoogleCloudVision.php
+++ b/src/GoogleCloudVision.php
@@ -82,15 +82,7 @@ class GoogleCloudVision
      */
     public function convertImgtoBased64($path)
     {
-        $urlParts = pathinfo($path);
-        $extension = $urlParts['extension'];
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $path);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-        curl_setopt($ch, CURLOPT_HEADER, 0);
-        $response = curl_exec($ch);
-        curl_close($ch);
+        $response = file_get_contents($path);
         $base64 = base64_encode($response);
         return $base64;
     }

--- a/tests/GoogleCloudVisionTest.php
+++ b/tests/GoogleCloudVisionTest.php
@@ -1,6 +1,6 @@
 <?php
 use GoogleCloudVisionPHP\GoogleCloudVision;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\PHPUnit\Framework\TestCase;
 
 /**
  * Class GoogleCloudVisionTest
@@ -28,6 +28,7 @@ class GoogleCloudVisionTest extends PHPUnit_Framework_TestCase
     {
         $countbase64 = strlen($this->gcv->convertImgtoBased64($this->filePath));
         $this->assertEquals($countbase64, 41700);
+
     }
 
     public function testSetImageWithFile()

--- a/tests/GoogleCloudVisionTest.php
+++ b/tests/GoogleCloudVisionTest.php
@@ -26,7 +26,7 @@ class GoogleCloudVisionTest extends PHPUnit_Framework_TestCase
     public function testConvertImgtoBased64()
     {
         $countbase64 = strlen($this->gcv->convertImgtoBased64($this->filePath));
-        $this->assertEquals($countbase64, 41722);
+        $this->assertEquals($countbase64, 41700);
     }
 
     public function testSetImageWithFile()

--- a/tests/GoogleCloudVisionTest.php
+++ b/tests/GoogleCloudVisionTest.php
@@ -1,6 +1,6 @@
 <?php
 use GoogleCloudVisionPHP\GoogleCloudVision;
-use PHPUnit\PHPUnit\Framework\TestCase as PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase as PHPUnit_Framework_TestCase;
 
 /**
  * Class GoogleCloudVisionTest

--- a/tests/GoogleCloudVisionTest.php
+++ b/tests/GoogleCloudVisionTest.php
@@ -1,5 +1,6 @@
 <?php
 use GoogleCloudVisionPHP\GoogleCloudVision;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class GoogleCloudVisionTest

--- a/tests/GoogleCloudVisionTest.php
+++ b/tests/GoogleCloudVisionTest.php
@@ -1,6 +1,6 @@
 <?php
 use GoogleCloudVisionPHP\GoogleCloudVision;
-use PHPUnit\PHPUnit\Framework\TestCase;
+use PHPUnit\PHPUnit\Framework\TestCase as PHPUnit_Framework_TestCase;
 
 /**
  * Class GoogleCloudVisionTest

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,3 +1,4 @@
 <?php
 
 require_once __DIR__.'/../src/autoload.php'; // GoogleCloudVision
+require_once __DIR__.'/../vendor/autoload.php'; // for PHP Unit 


### PR DESCRIPTION
The base64 decoding didn't work for me, and I saw no reason to use curl at all for this. Especially as I'm mostly doing this on local (or at least mounted locally) files. 

Simply replaced curl with file_get_contents which should do the job. I've noticed someone else has done this in their fork too, but thought I'd put up a pull request with the change). 

My main concern with this is that the "RAW" is actually base64 encoded which is doing the same thing now. Pretty sure we could get rid of the "RAW" part of it, and will need to update the test. I'm unsure what the previous version was doing.

If I've done something wrong or could do it better please let me know :) 
